### PR TITLE
Stop losing pixels when resizing Atari images

### DIFF
--- a/envs.py
+++ b/envs.py
@@ -163,6 +163,10 @@ class DiagnosticsInfoI(vectorized.Filter):
 
 def _process_frame42(frame):
     frame = frame[34:34+160, :160]
+    # Resize by half, then down to 42x42 (essentially mipmapping). If
+    # we resize directly we lose pixels that, when mapped to 42x42,
+    # aren't close enough to the pixel boundary.
+    frame = cv2.resize(frame, (80, 80))
     frame = cv2.resize(frame, (42, 42))
     frame = frame.mean(2)
     frame = frame.astype(np.float32)


### PR DESCRIPTION
For reference, here are examples of images that were resized incorrectly. Notice the ball hiding at first, and slowly re-appearing.

I verified over several dozen frames that the ball no longer disappears with the new resizing code.

<img src="https://cloud.githubusercontent.com/assets/37586/20653726/c30de798-b4c6-11e6-8454-3101bdbef760.png" width="220" height="220">
<img src="https://cloud.githubusercontent.com/assets/37586/20653726/c30de798-b4c6-11e6-8454-3101bdbef760.png" width="220" height="220">
<img src="https://cloud.githubusercontent.com/assets/37586/20653728/c30e8b6c-b4c6-11e6-9e9e-eb180b3a7b37.png" width="220" height="220">
