### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ It contains a basic implementation of A3C algorithm, adapted for real-time envir
 
 # Dependencies
 
-* Numpy 1.12
 * Python 2.7 or 3.5
 * six (for py2/3 compatibility)
 * TensorFlow 0.11
@@ -13,6 +12,7 @@ It contains a basic implementation of A3C algorithm, adapted for real-time envir
 * gym
 * universe
 * opencv-python
+* numpy
 * scipy
 
 # Getting Started


### PR DESCRIPTION
My universe-starter-agent is working fine without Anaconda so I removed it from the list of dependencies on the README.md. As usual, Anaconda is really only a dependency if you don't have gcc.