### PR TITLE
Update train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -58,7 +58,7 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
 
 def run():
     args = parser.parse_args()
-    os.system("tmux kill-session")
+    os.system("tmux kill-session -t a3c")
     cmds = create_tmux_commands("a3c", args.num_workers, args.remotes, args.env_id, args.log_dir)
     print("\n".join(cmds))
     os.system("\n".join(cmds))

--- a/train.py
+++ b/train.py
@@ -38,7 +38,7 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
         cmds_map += [new_tmux_cmd(
             "w-%d" % i, base_cmd + ["--job-name", "worker", "--task", str(i), "--remotes", remotes[i]])]
 
-    cmds_map += [new_tmux_cmd("tb", ["tensorboard --logdir {} --port 12345".format(logdir)])]
+    cmds_map += [new_tmux_cmd("tb", ["tensorboard --logdir {} --port 6006".format(logdir)])]
     cmds_map += [new_tmux_cmd("htop", ["htop"])]
 
     windows = [v[0] for v in cmds_map]

--- a/train.py
+++ b/train.py
@@ -45,7 +45,6 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
 
     cmds = [
         "mkdir -p {}".format(logdir),
-        "tmux kill-session",
         "tmux new-session -s {} -n {} -d".format(session, windows[0]),
     ]
     for w in windows[1:]:
@@ -59,7 +58,7 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
 
 def run():
     args = parser.parse_args()
-
+    os.system("tmux kill-session")
     cmds = create_tmux_commands("a3c", args.num_workers, args.remotes, args.env_id, args.log_dir)
     print("\n".join(cmds))
     os.system("\n".join(cmds))


### PR DESCRIPTION
My computer had issues with using port 12345 so I used tensorflows default port number 6006 (goog upside down) and no longer had issues.

Readme updated to reflect changes in https://github.com/openai/universe-starter-agent/pull/19

Moved the location of the os.system command kill tmux-session to prevent tmux returning a no server error.  This should be the solution to the issue, everything works great for me.