### PR TITLE
commands sent to tmux expect 'sh' like shell

### DIFF
--- a/train.py
+++ b/train.py
@@ -46,7 +46,7 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir, shell='s
     cmds = [
         "mkdir -p {}".format(logdir),
         "tmux kill-session",
-        "tmux new-session -s {} -n {} -d".format(session, windows[0]),
+        "tmux new-session -s {} -n {} -d {}".format(session, windows[0], shell),
     ]
     for w in windows[1:]:
         cmds += ["tmux new-window -t {} -n {} {}".format(session, w, shell)]

--- a/train.py
+++ b/train.py
@@ -20,7 +20,7 @@ def new_tmux_cmd(name, cmd):
     return name, "tmux send-keys -t {} '{}' Enter".format(name, cmd)
 
 
-def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
+def create_tmux_commands(session, num_workers, remotes, env_id, logdir, shell='sh'):
     # for launching the TF workers and for launching tensorboard
     base_cmd = [
         'CUDA_VISIBLE_DEVICES=', sys.executable, 'worker.py',
@@ -49,7 +49,7 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
         "tmux new-session -s {} -n {} -d".format(session, windows[0]),
     ]
     for w in windows[1:]:
-        cmds += ["tmux new-window -t {} -n {}".format(session, w)]
+        cmds += ["tmux new-window -t {} -n {} {}".format(session, w, shell)]
     cmds += ["sleep 1"]
     for window, cmd in cmds_map:
         cmds += [cmd]


### PR DESCRIPTION
The commands you are creating expect to be sent to an 'sh' like shell like bash. 
especially, the way of setting variables on the beginning of the command is not supported by the fish shell, so train.py fails to start the commands
```
fish ~/w/universe-starter-agent> CUDA_VISIBLE_DEVICES= /usr/local/opt/python/bin/python2.7 worker.py --log-dir /tmp/pong --env-id PongDeterministic-v3 --num-workers 2 --job-name ps
Unsupported use of '='. To run '/usr/local/opt/python/bin/python2.7' with a modified environment, please use 'env CUDA_VISIBLE_DEVICES= /usr/local/opt/python/bin/python2.7…'
```

Starting tmux with a command to run that is 'sh' fixes this.