### PR TITLE
Update README - added links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It contains a basic implementation of the [A3C algorithm](https://arxiv.org/abs/
 * [TensorFlow](https://www.tensorflow.org/) 0.11
 * [tmux](https://tmux.github.io/) (the start script opens up a tmux session with multiple windows)
 * [htop](https://hisham.hm/htop/) (shown in one of the tmux windows)
-* gym
+* [gym](https://pypi.python.org/pypi/gym)
 * gym[atari]
-* universe
+* [universe](https://pypi.python.org/pypi/universe)
 * [opencv-python](https://pypi.python.org/pypi/opencv-python)
 * [numpy](https://pypi.python.org/pypi/numpy)
 * [scipy](https://pypi.python.org/pypi/scipy)

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ It contains a basic implementation of the [A3C algorithm](https://arxiv.org/abs/
 # Dependencies
 
 * Python 2.7 or 3.5
-* six (for py2/3 compatibility)
-* TensorFlow 0.11
-* tmux (the start script opens up a tmux session with multiple windows)
-* htop (shown in one of the tmux windows)
+* [six](https://pypi.python.org/pypi/six) (for py2/3 compatibility)
+* [TensorFlow](https://www.tensorflow.org/) 0.11
+* [tmux](https://tmux.github.io/) (the start script opens up a tmux session with multiple windows)
+* [htop](https://hisham.hm/htop/) (shown in one of the tmux windows)
 * gym
 * gym[atari]
 * universe
-* opencv-python
-* numpy
-* scipy
+* [opencv-python](https://pypi.python.org/pypi/opencv-python)
+* [numpy](https://pypi.python.org/pypi/numpy)
+* [scipy](https://pypi.python.org/pypi/scipy)
 
 # Getting Started
 


### PR DESCRIPTION
Ran into an issue earlier with opencv not being imported properly (#6) only to realize later on that it was easily fixed by installing a newer version. I think it would be helpful to have links to these packages since we don't have a package manager checking for these at the moment. 

Lmk if this looks good. Are gym and universe published as packages? If so, I'll update the PR with those links. 