### PR TITLE
add session parameter to new_tmux_cmd

### DIFF
--- a/train.py
+++ b/train.py
@@ -14,10 +14,10 @@ parser.add_argument('-l', '--log-dir', type=str, default="/tmp/pong",
                     help="Log directory path")
 
 
-def new_tmux_cmd(name, cmd):
+def new_tmux_cmd(session, name, cmd):
     if isinstance(cmd, (list, tuple)):
         cmd = " ".join(str(v) for v in cmd)
-    return name, "tmux send-keys -t {} '{}' Enter".format(name, cmd)
+    return name, "tmux send-keys -t {}:{} '{}' Enter".format(session, name, cmd)
 
 
 def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
@@ -33,19 +33,19 @@ def create_tmux_commands(session, num_workers, remotes, env_id, logdir):
         remotes = remotes.split(',')
         assert len(remotes) == num_workers
 
-    cmds_map = [new_tmux_cmd("ps", base_cmd + ["--job-name", "ps"])]
+    cmds_map = [new_tmux_cmd(session, "ps", base_cmd + ["--job-name", "ps"])]
     for i in range(num_workers):
-        cmds_map += [new_tmux_cmd(
+        cmds_map += [new_tmux_cmd(session,
             "w-%d" % i, base_cmd + ["--job-name", "worker", "--task", str(i), "--remotes", remotes[i]])]
 
-    cmds_map += [new_tmux_cmd("tb", ["tensorboard --logdir {} --port 12345".format(logdir)])]
-    cmds_map += [new_tmux_cmd("htop", ["htop"])]
+    cmds_map += [new_tmux_cmd(session, "tb", ["tensorboard --logdir {} --port 12345".format(logdir)])]
+    cmds_map += [new_tmux_cmd(session, "htop", ["htop"])]
 
     windows = [v[0] for v in cmds_map]
 
     cmds = [
         "mkdir -p {}".format(logdir),
-        "tmux kill-session",
+        "tmux kill-session -t {}".format(session),
         "tmux new-session -s {} -n {} -d".format(session, windows[0]),
     ]
     for w in windows[1:]:


### PR DESCRIPTION
Running train.py kills any preexisting tmux sessions. This is quite unexpected and can be very annoying if you are running train.py from a tmux session. This commit fixes the tmux kill-session command to only kill a specific session (e.g. old "a3c" sessions). In turn, as the new "a3c" session now may not be the only running session, new_tmux_cmd is extended with a session parameter.