### PR TITLE
Resets grpc properly between runs (prevent random thread / process crashes)

### DIFF
--- a/a3c.py
+++ b/a3c.py
@@ -171,7 +171,7 @@ should be computed.
         # Only visualise first agent
         if (task > 0):
             visualise = False
-            
+
         self.env = env
         self.task = task
         worker_device = "/job:worker/task:{}/cpu:0".format(task)
@@ -242,8 +242,8 @@ should be computed.
             grads_and_vars = list(zip(grads, self.network.var_list))
             inc_step = self.global_step.assign_add(tf.shape(pi.x)[0])
 
-            # each worker has a different set of adam optimizer parameters
-            opt = tf.train.AdamOptimizer(1e-4)
+            # each worker has a different set of Nadam optimizer parameters
+            opt = tf.train.NadamOptimizer(2e-4)
             self.train_op = tf.group(opt.apply_gradients(grads_and_vars), inc_step)
             self.summary_writer = None
             self.local_steps = 0

--- a/a3c.py
+++ b/a3c.py
@@ -198,7 +198,7 @@ should be computed.
             entropy = - tf.reduce_sum(prob_tf * log_prob_tf)
 
             bs = tf.to_float(tf.shape(pi.x)[0])
-            self.loss = pi_loss + 0.5 * vf_loss - entropy * 0.01
+            self.loss = pi_loss + 0.5 * vf_loss - entropy * 0.009
 
             # 20 represents the number of "local steps":  the number of timesteps
             # we run the policy before we update the parameters.
@@ -206,7 +206,7 @@ should be computed.
             # on the one hand;  but on the other hand, we get less frequent parameter updates, which
             # slows down learning.  In this code, we found that making local steps be much
             # smaller than 20 makes the algorithm more difficult to tune and to get to work.
-            self.runner = RunnerThread(env, pi, 20, visualise)
+            self.runner = RunnerThread(env, pi, 15, visualise)
 
 
             grads = tf.gradients(self.loss, pi.var_list)

--- a/a3c.py
+++ b/a3c.py
@@ -167,6 +167,11 @@ But overall, we'll define the model, specify its inputs, and describe how the po
 should be computed.
 """
 
+
+        # Only visualise first agent
+        if (task > 0):
+            visualise = False
+            
         self.env = env
         self.task = task
         worker_device = "/job:worker/task:{}/cpu:0".format(task)

--- a/train.py
+++ b/train.py
@@ -80,6 +80,8 @@ def create_commands(session, num_workers, remotes, env_id, logdir, shell='bash',
 
     if mode == 'tmux':
         cmds += [
+        "kill $( lsof -i:12345 -t ) > /dev/null 2>&1",  # kill any process using tensorboard's port
+        "kill $( lsof -i:12222-{} -t ) > /dev/null 2>&1".format(num_workers+12222), # kill any processes using ps / worker ports
         "tmux kill-session -t {}".format(session),
         "tmux new-session -s {} -n {} -d {}".format(session, windows[0], shell)
         ]


### PR DESCRIPTION
Grpc has a nasty habit of hanging during SIGHUP rather than exiting cleanly when restarting tensorflow clusters via tmux session-kill calls. This issue (or one like it) is mentioned in passing here (https://github.com/openai/universe-starter-agent/issues/44)

This bug isn't ubiquitous, but it's definitely present. It's annoying when it poisons the processing environment and leaves it littered with defunct / oprhaned grpc processes that are blocking the ports you're about to re-open when restarting the agents.

I'll eventually fix Tensorflow itself. But for now, this patch resets the the environment more fully between runs so others don't end up with errors like the one below (which don't leave a trace in logs, BTW).


Please cherry pick just 3614229.

[ Sorry my PRs are gross. I'm new here. :D I know how to remove the extra 3 commits from your side if that helps. Let me know. ]





```
CUDA_VISIBLE_DEVICES= /usr/bin/python worker.py --log-dir /tmp/pong4579 --env-id PongDeterministic-v3 --num-workers 16 --visualise --job-name ps
[2017-02-24 17:17:08,231] Writing logs to file: /tmp/universe-21944.log
E0224 17:17:08.289240788   21944 server_chttp2.c:159]        {"created":"@1487931428.289200252","description":"No address added out of total 1 resolved","file":"external/grpc/src/core/ext/transport/chttp2/server/insecure/server_chttp2.c","file_line":125,"referenced_errors":[{"created":"@1487931428.289197827","description":"Failed to add port to server","file":"external/grpc/src/core/lib/iomgr/tcp_server_posix.c","file_line":634,"referenced_errors":[{"created":"@1487931428.289162540","description":"OS Error","errno":97,"file":"external/grpc/src/core/lib/iomgr/socket_utils_common_posix.c","file_line":260,"os_error":"Address family not supported by protocol","syscall":"socket","target_address":"[::]:12222"}{"created":"@1487931428.289189647","description":"Unable to configure socket","fd":15,"file":"external/grpc/src/core/lib/iomgr/tcp_server_posix.c","file_line":355,"referenced_errors":[{"created":"@1487931428.289183016","description":"OS Error","errno":98,"file":"external/grpc/src/core/lib/iomgr/tcp_server_posix.c","file_line":331,"os_error":"Address already in use","syscall":"bind"}]}],"target_address":"ipv4:0.0.0.0:12222"}]}
Traceback (most recent call last):
  File "worker.py", line 170, in <module>
    tf.app.run()
  File "/usr/lib/python3.6/site-packages/tensorflow/python/platform/app.py", line 44, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "worker.py", line 165, in main
    config=tf.ConfigProto(device_filters=["/job:ps"]))
  File "/usr/lib/python3.6/site-packages/tensorflow/python/training/server_lib.py", line 144, in __init__
    self._server_def.SerializeToString(), status)
  File "/usr/lib/python3.6/contextlib.py", line 89, in __exit__
    next(self.gen)
  File "/usr/lib/python3.6/site-packages/tensorflow/python/framework/errors_impl.py", line 466, in raise_exception_on_not_ok_status
    pywrap_tensorflow.TF_GetCode(status))
tensorflow.python.framework.errors_impl.UnknownError: Could not start gRPC server
```
