### PR TITLE
Parameter Inconsistency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It contains a basic implementation of the [A3C algorithm](https://arxiv.org/abs/
 
 * Python 2.7 or 3.5
 * [six](https://pypi.python.org/pypi/six) (for py2/3 compatibility)
-* [TensorFlow](https://www.tensorflow.org/) 0.12
+* [TensorFlow](https://www.tensorflow.org/) 1.0
 * [tmux](https://tmux.github.io/) (the start script opens up a tmux session with multiple windows)
 * [htop](https://hisham.hm/htop/) (shown in one of the tmux windows)
 * [gym](https://pypi.python.org/pypi/gym)

--- a/a3c.py
+++ b/a3c.py
@@ -245,7 +245,11 @@ should be computed.
             inc_step = self.global_step.assign_add(tf.shape(pi.x)[0])
 
             # each worker has a different set of adam optimizer parameters
-            opt = tf.train.AdamOptimizer(1e-4)
+            if use_tf100_api:
+                with tf.variable_scope("Adam_ResourceVariables", use_resource=True):
+                    opt = tf.train.AdamOptimizer(1e-4)
+            else:
+                opt = tf.train.AdamOptimizer(1e-4)
             self.train_op = tf.group(opt.apply_gradients(grads_and_vars), inc_step)
             self.summary_writer = None
             self.local_steps = 0


### PR DESCRIPTION
This branch converts all global network Variables to ResourceVariable class https://github.com/tensorflow/tensorflow/issues/6360#issuecomment-271741913 by setting `use_resource=True` for global variable_scope to fix the parameter inconsistency issue mentioned in https://github.com/tensorflow/tensorflow/issues/6360#issuecomment-271486091 .

It also puts `opt = tf.train.AdamOptimizer(1e-4)` inside of a scope with `use_resource=True` to (hopefully) prevent updates based on inconsistent Adam momentum and variance accumulator parameters mentioned in https://github.com/openai/universe-starter-agent/issues/67#issuecomment-287343303 .

These changes still needs to A/B tested to see if there's a noticeable positive performance difference. If so, TensorFlow dependency in Readme should be changed to version 1.0 so that future users don't succumb to parameter inconsistency issues.