### PR TITLE
GRU-A3C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,151 +1,73 @@
-# universe-starter-agent
+# High performance GRU-A3C agent
 
-The codebase implements a starter agent that can solve a number of `universe` environments.
-It contains a basic implementation of the [A3C algorithm](https://arxiv.org/abs/1602.01783), adapted for real-time environments.
+- 80% performance increase over the current LSTM-based A3C starter agent on `PongDeterministic-v3` environment.
 
-# Dependencies
+- 20% higher throughput in all Atari environments.
 
-* Python 2.7 or 3.5
-* [six](https://pypi.python.org/pypi/six) (for py2/3 compatibility)
-* [TensorFlow](https://www.tensorflow.org/) 0.12
-* [tmux](https://tmux.github.io/) (the start script opens up a tmux session with multiple windows)
-* [htop](https://hisham.hm/htop/) (shown in one of the tmux windows)
-* [gym](https://pypi.python.org/pypi/gym)
-* gym[atari]
-* [universe](https://pypi.python.org/pypi/universe)
-* [opencv-python](https://pypi.python.org/pypi/opencv-python)
-* [numpy](https://pypi.python.org/pypi/numpy)
-* [scipy](https://pypi.python.org/pypi/scipy)
+- 10-100% data-efficiency increase in various Atari environments. This boost is not well-characterized or well-tuned yet.
 
-# Getting Started
+- 3 small, initial hyperparameter changes extend these gains even more.
 
-```
-conda create --name universe-starter-agent python=3.5
-source activate universe-starter-agent
+- Using recently added NADAM optimizer vs ADAM
 
-brew install tmux htop cmake      # On Linux use sudo apt-get install -y tmux htop cmake
+- GRU-based RNNs appear both more stable and more tolerant of a wider hyperparameter space than LSTMs for discrete RL tasks.
 
-pip install "gym[atari]"
-pip install universe
-pip install six
-pip install tensorflow
-conda install -y -c https://conda.binstar.org/menpo opencv3
-conda install -y numpy
-conda install -y scipy
-```
+- Research cycles were shortened 30% more by MKL-optimized [`manjaro-ml-dotfiles`](https://github.com/louiehelm/manjaro-ml-dotfiles). This improves upon the recommended `universe` dev environment of `ubuntu` + `anaconda`.
 
 
-Add the following to your `.bashrc` so that you'll have the correct environment when the `train.py` script spawns new bash shells
-```source activate universe-starter-agent```
+## New GRU-A3C Agent (~3x faster @ Atari Pong)
 
-## Atari Pong
 
-`python train.py --num-workers 2 --env-id PongDeterministic-v3 --log-dir /tmp/pong`
+`python train.py --num-workers 8 --env-id PongDeterministic-v3 --visualise --log-dir /tmp/pong`
 
-The command above will train an agent on Atari Pong using ALE simulator.
-It will see two workers that will be learning in parallel (`--num-workers` flag) and will output intermediate results into given directory.
+GRU-A3C can solve `PongDeterministic-v3` in under **30 minutes** on a high-end Mac (vs **2 hours** for the original starter agent). To solve `PongDeterministic-v3` in 30 minutes before, the LSTM-based agent required 2x as many agents, runing on 4x as many cores, all at higher clock speeds.
 
-The code will launch the following processes:
-* worker-0 - a process that runs policy gradient
-* worker-1 - a process identical to process-1, that uses different random noise from the environment
-* ps - the parameter server, which synchronizes the parameters among the different workers
-* tb - a tensorboard process for convenient display of the statistics of learning
+![pong](http://i.imgur.com/QphU60g.png "GRU Pong")
 
-Once you start the training process, it will create a tmux session with a window for each of these processes. You can connect to them by typing `tmux a` in the console.
-Once in the tmux session, you can see all your windows with `ctrl-b w`.
-To switch to window number 0, type: `ctrl-b 0`. Look up tmux documentation for more commands.
 
-To access TensorBoard to see various monitoring metrics of the agent, open [http://localhost:12345/](http://localhost:12345/) in a browser.
+This smaller pool of agents can also solve `PongDeterministic-v3` with fewer total frames (~900k vs 2.5-3.2M). Data efficiency gains from GRU-based A3C agents need more characterization but definitely appear significant.
 
-Using 16 workers, the agent should be able to solve `PongDeterministic-v3` (not VNC) within 30 minutes (often less) on an `m4.10xlarge` instance.
-Using 32 workers, the agent is able to solve the same environment in 10 minutes on an `m4.16xlarge` instance.
-If you run this experiment on a high-end MacBook Pro, the above job will take just under 2 hours to solve Pong.
 
-Add '--visualise' toggle if you want to visualise the worker using env.render() as follows:
+# Major Changes
 
-`python train.py --num-workers 2 --env-id PongDeterministic-v3 --log-dir /tmp/pong --visualise`
+* Replace LSTMs in A3C model with [more principled GRUs](http://colah.github.io/posts/2015-08-Understanding-LSTMs/)
+* RNN switched to time-major data format to avoid two extra transposes per step
 
-![pong](https://github.com/openai/universe-starter-agent/raw/master/imgs/tb_pong.png "Pong")
 
-For best performance, it is recommended for the number of workers to not exceed available number of CPU cores.
+# Minor Changes
 
-You can stop the experiment with `tmux kill-session` command.
+* 100% higher learning rate with slower decay
+* ADAM optimizer -> [NADAM optimizer](https://github.com/tensorflow/tensorflow/commit/86d3891ba6612552347beaabe27edac11f5758d7)
+* Local steps increased 20 -> 30
+* 10% dropout
+* Asyncronous visualiser
 
-## Playing games over remote desktop
 
-The main difference with the previous experiment is that now we are going to play the game through VNC protocol.
-The VNC environments are hosted on the EC2 cloud and have an interface that's different from a conventional Atari Gym
-environment;  luckily, with the help of several wrappers (which are used within `envs.py` file)
-the experience should be similar to the agent as if it was played locally. The problem itself is more difficult
-because the observations and actions are delayed due to the latency induced by the network.
+GRUs appear less overwhelmed by higher learning rates and more resilient to a wider range of hyperparams in general.
 
-More interestingly, you can also peek at what the agent is doing with a VNCViewer.
+Google recently accepted my NADAM patches into TensorFlow. It tends to converge faster and more stablely than ADAM in all but pathological cases. GRU-A3C works great with ADAM, but why not use the more principled, higher performance optimizer?
 
-Note that the default behavior of `train.py` is to start the remotes on a local machine. Take a look at https://github.com/openai/universe/blob/master/doc/remotes.rst for documentation on managing your remotes. Pass additional `-r` flag to point to pre-existing instances.
+Local steps can scale both lower and higher with GRU-based agents:
 
-### VNC Pong
+- 15 provides less actions per second but higher data efficiency
 
-`python train.py --num-workers 2 --env-id gym-core.PongDeterministic-v3 --log-dir /tmp/vncpong`
+- 30 provides more actions per second with slightly worse data efficiency
 
-_Peeking into the agent's environment with TurboVNC_
 
-You can use your system viewer as `open vnc://localhost:5900` (or `open vnc://${docker_ip}:5900`) or connect TurboVNC to that ip/port.
-VNC password is `"openai"`.
 
-![pong](https://github.com/openai/universe-starter-agent/raw/master/imgs/vnc_pong.png "Pong over VNC")
+These hyperparameter changes are not exhaustively tuned, nor the prime drivers of higher performance. They mostly serve to demonstrate a new set of learning parameters that was previously unworkable with LSTMs but which appears both well-behaved and high performance with GRUs in many environments.
 
-#### Important caveats
 
-One of the novel challenges in using Universe environments is that
-they operate in *real time*, and in addition, it takes time for the
-environment to transmit the observation to the agent.  This time
-creates a lag: where the greater the lag, the harder it is to solve
-environment with today's RL algorithms.  Thus, to get the best
-possible results it is necessary to reduce the lag, which can be
-achieved by having both the environments and the agent live
-on the same high-speed computer network.  So for example, if you have
-a fast local network, you could host the environments on one set of
-machines, and the agent on another machine that can speak to the
-environments with low latency.  Alternatively, you can run the
-environments and the agent on the same EC2/Azure region.  Other
-configurations tend to have greater lag.
 
-To keep track of your lag, look for the phrase `reaction_time` in
-stderr.  If you run both the agent and the environment on nearby
-machines on the cloud, your `reaction_time` should be as low as 40ms.
-The `reaction_time` statistic is printed to stderr because we wrap our
-environment with the `Logger` wrapper, as done in
-[here](<https://github.com/openai/universe-starter-agent/blob/master/envs.py#L32>).
+## Terminal Visualiser
 
-Generally speaking, environments that are most affected by lag are
-games that place a lot of emphasis on reaction time.  For example,
-this agent is able to solve VNC Pong
-(`gym-core.PongDeterministic-v3`) in under 2 hours when both the agent
-and the environment are co-located on the cloud, but this agent had
-difficulty solving VNC Pong when the environment was on the cloud
-while the agent was not.  This issue affects environments that place
-great emphasis on reaction time.
+![vis](http://i.imgur.com/oFuBqJP.jpg "Terminal Visualiser")
 
-### A note on tuning
+Display 2 running agents: `./term_vis.sh 2` 
 
-This implementation has been tuned to do well on VNC Pong, and we do not guarantee
-its performance on other tasks.  It is meant as a starting point.
+There is also a small code patch to allow asyncronous visualisation via bash script (requires w3m-img)
 
-### Playing flash games
-
-You may run the following command to launch the agent on the game Neon Race:
-
-`python train.py --num-workers 2 --env-id flashgames.NeonRace-v0 --log-dir /tmp/neonrace`
-
-_What agent sees when playing Neon Race_
-(you can connect to this view via [note](#vnc-pong) above)
-![neon](https://github.com/openai/universe-starter-agent/raw/master/imgs/neon_race.png "Neon Race")
-
-Getting 80% of the maximal score takes between 1 and 2 hours with 16 workers, and getting to 100% of the score
-takes about 12 hours.  Also, flash games are run at 5fps by default, so it should be possible to productively
-use 16 workers on a machine with 8 (and possibly even 4) cores.
-
-### Next steps
-
-Now that you have seen an example agent, develop agents of your own.  We hope that you will find
-doing so to be an exciting and an enjoyable task.
+* Visualisation can be switched on / off even on live training runs
+* Uses 60% less CPU per frame vs pyglet when actively displaying
+* Workers spend 0% CPU updating visualisation unless  the script is actually running
+* Can visualise over SSH via X-Forwarded terminals (e.g., ssh -L localhost:12345:localhost:12345 -Ycv -i <.pem file> ubuntu@xxx.xxx.xxx.xxx) [see above]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 - 3 small, initial hyperparameter changes extend these gains even more.
 
-- Using recently added NADAM optimizer vs ADAM
-
 - GRU-based RNNs appear both more stable and more tolerant of a wider hyperparameter space than LSTMs for discrete RL tasks.
 
 - Research cycles were shortened 30% more by MKL-optimized [`manjaro-ml-dotfiles`](https://github.com/louiehelm/manjaro-ml-dotfiles). This improves upon the recommended `universe` dev environment of `ubuntu` + `anaconda`.
@@ -37,15 +35,12 @@ This smaller pool of agents can also solve `PongDeterministic-v3` with fewer tot
 # Minor Changes
 
 * 100% higher learning rate with slower decay
-* ADAM optimizer -> [NADAM optimizer](https://github.com/tensorflow/tensorflow/commit/86d3891ba6612552347beaabe27edac11f5758d7)
 * Local steps increased 20 -> 30
 * 10% dropout
 * Asyncronous visualiser
 
 
 GRUs appear less overwhelmed by higher learning rates and more resilient to a wider range of hyperparams in general.
-
-Google recently accepted my NADAM patches into TensorFlow. It tends to converge faster and more stablely than ADAM in all but pathological cases. GRU-A3C works great with ADAM, but why not use the more principled, higher performance optimizer?
 
 Local steps can scale both lower and higher with GRU-based agents:
 

--- a/a3c.py
+++ b/a3c.py
@@ -241,7 +241,7 @@ should be computed.
             inc_step = self.global_step.assign_add(tf.shape(pi.x)[0])
 
             # each worker has a different set of adam optimizer parameters
-            opt = tf.train.NadamOptimizer(2e-4)
+            opt = tf.train.AdamOptimizer(learning_rate=0.0002, beta1=0.825, beta2=0.99685)
             self.train_op = tf.group(opt.apply_gradients(grads_and_vars), inc_step)
             self.summary_writer = None
             self.local_steps = 0

--- a/model.py
+++ b/model.py
@@ -44,53 +44,41 @@ def categorical_sample(logits, d):
     value = tf.squeeze(tf.multinomial(logits - tf.reduce_max(logits, [1], keep_dims=True), 1), [1])
     return tf.one_hot(value, d)
 
-class LSTMPolicy(object):
+class GRUPolicy(object):
     def __init__(self, ob_space, ac_space):
         self.x = x = tf.placeholder(tf.float32, [None] + list(ob_space))
 
         for i in range(4):
             x = tf.nn.elu(conv2d(x, 32, "l{}".format(i + 1), [3, 3], [2, 2]))
         # introduce a "fake" batch dimension of 1 after flatten so that we can do LSTM over time dim
-        x = tf.expand_dims(flatten(x), [0])
-
+        x = tf.expand_dims(flatten(x), 1)
+        x = tf.nn.dropout(x, 0.9)
         size = 256
-        if use_tf100_api:
-            lstm = rnn.BasicLSTMCell(size, state_is_tuple=True)
-        else:
-            lstm = rnn.rnn_cell.BasicLSTMCell(size, state_is_tuple=True)
-        self.state_size = lstm.state_size
-        step_size = tf.shape(self.x)[:1]
+        gru = rnn.GRUCell(size)
 
-        c_init = np.zeros((1, lstm.state_size.c), np.float32)
-        h_init = np.zeros((1, lstm.state_size.h), np.float32)
-        self.state_init = [c_init, h_init]
-        c_in = tf.placeholder(tf.float32, [1, lstm.state_size.c])
-        h_in = tf.placeholder(tf.float32, [1, lstm.state_size.h])
-        self.state_in = [c_in, h_in]
+        h_init = np.zeros((1, size), np.float32)
+        self.state_init = [h_init]
+        h_in = tf.placeholder(tf.float32, [1, size])
+        self.state_in = [h_in]
 
-        if use_tf100_api:
-            state_in = rnn.LSTMStateTuple(c_in, h_in)
-        else:
-            state_in = rnn.rnn_cell.LSTMStateTuple(c_in, h_in)
-        lstm_outputs, lstm_state = tf.nn.dynamic_rnn(
-            lstm, x, initial_state=state_in, sequence_length=step_size,
-            time_major=False)
-        lstm_c, lstm_h = lstm_state
-        x = tf.reshape(lstm_outputs, [-1, size])
+        gru_outputs, gru_state = tf.nn.dynamic_rnn(
+            gru, x, initial_state=h_in, sequence_length=[size], time_major=True)
+
+        x = tf.reshape(gru_outputs, [-1, size])
         self.logits = linear(x, ac_space, "action", normalized_columns_initializer(0.01))
         self.vf = tf.reshape(linear(x, 1, "value", normalized_columns_initializer(1.0)), [-1])
-        self.state_out = [lstm_c[:1, :], lstm_h[:1, :]]
+        self.state_out = [gru_state[:1]]
         self.sample = categorical_sample(self.logits, ac_space)[0, :]
         self.var_list = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, tf.get_variable_scope().name)
 
     def get_initial_features(self):
         return self.state_init
 
-    def act(self, ob, c, h):
+    def act(self, ob, h):
         sess = tf.get_default_session()
         return sess.run([self.sample, self.vf] + self.state_out,
-                        {self.x: [ob], self.state_in[0]: c, self.state_in[1]: h})
+                        {self.x: [ob], self.state_in[0]: h})
 
-    def value(self, ob, c, h):
+    def value(self, ob, h):
         sess = tf.get_default_session()
-        return sess.run(self.vf, {self.x: [ob], self.state_in[0]: c, self.state_in[1]: h})[0]
+        return sess.run(self.vf, {self.x: [ob], self.state_in[0]: h})[0]

--- a/term_vis.sh
+++ b/term_vis.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Show 1 agent if no arg given
+num_agents=$1
+if [ -z "$num_agents" ];then
+    num_agents=1
+fi
+
+term_col=`tput cols`
+term_lines=`tput lines`
+
+trap "tput cnorm; exit" SIGHUP SIGINT SIGTERM
+tput civis
+
+
+scale=1
+if [ "$num_agents" == "1" ];then
+    (( scale = 3 ))
+elif [ "$num_agents" == "2" ];then
+    (( scale = 2 ))
+elif [ "$num_agents" == "3" ];then
+    (( scale = 1.5 ))
+elif [ "$num_agents" == "4" ];then
+    (( scale = 1.25 ))
+fi
+
+(( game_width  = 160 * scale ))
+(( game_height = 210 * scale ))
+
+
+
+(( x_offset = 28 ))
+(( y_offset = 72 ))
+
+
+# clear spot for agents
+for ((i=0; i<=$term_lines/2; i++)); do echo -e "\n"; done
+
+
+# draw agents
+
+# Press "1" to switches to low-speed updates (for SSH)
+
+(( fps = 60 ))
+
+for (( ; ; ))
+do
+
+   if [ "$fps" == "60" ];then
+      read -t 0.0167 -r -s -n 1 input
+   else
+      read -t 0.5 -r -s -n 1 input
+   fi
+
+   if [ "$input" == "1" ];then
+      if [ "$fps" == "60" ];then
+         (( fps = 2 ))
+      else
+         (( fps = 60 ))
+      fi
+   fi
+
+   for (( i=0; i<num_agents; i++ ))
+   do
+      if [ -f /tmp/universe$i.bmp ]; then
+         ((x = x_offset + i * (game_width + x_offset) )) 
+         mv /tmp/universe$i.bmp /tmp/back-universe$i.bmp
+
+         echo -e "0;1;${x};${y_offset};${game_width};${game_height};0;0;0;0;/tmp/back-universe${i}.bmp\n3;" | /usr/lib/w3m/w3mimgdisplay
+
+      fi
+   done
+
+
+done


### PR DESCRIPTION
I'm getting positive results by replacing LSTMs --> GRUs in your A3C implementation.

Wrote up a short report:
https://github.com/louiehelm/universe-starter-agent/blob/gru/README.md

I know the starter agent is a reference design, so you may not want to include every possible improvement.

OTOH, switching to GRUs makes the code shorter, avoids creating an extra tuple, removes two transposes per pass, runs at higher throughput, and seems to be generally dominant vs LSTMs for every environment I've tested so far.

I know my own research cycles are much faster with this version and data-efficiency is up a lot, which makes trying new ideas way easier.