### PR TITLE
Change demo to PongDeterministic-v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add the following to your `.bashrc` so that you'll have the correct environment 
 
 ## Atari Pong
 
-`python train.py --num-workers 2 --env-id PongDeterministic-v3 --log-dir /tmp/pong`
+`python train.py --num-workers 2 --env-id PongDeterministic-v4 --log-dir /tmp/pong`
 
 The command above will train an agent on Atari Pong using ALE simulator.
 It will see two workers that will be learning in parallel (`--num-workers` flag) and will output intermediate results into given directory.
@@ -59,13 +59,13 @@ To switch to window number 0, type: `ctrl-b 0`. Look up tmux documentation for m
 
 To access TensorBoard to see various monitoring metrics of the agent, open [http://localhost:12345/](http://localhost:12345/) in a browser.
 
-Using 16 workers, the agent should be able to solve `PongDeterministic-v3` (not VNC) within 30 minutes (often less) on an `m4.10xlarge` instance.
+Using 16 workers, the agent should be able to solve `PongDeterministic-v4` (not VNC) within 30 minutes (often less) on an `m4.10xlarge` instance.
 Using 32 workers, the agent is able to solve the same environment in 10 minutes on an `m4.16xlarge` instance.
 If you run this experiment on a high-end MacBook Pro, the above job will take just under 2 hours to solve Pong.
 
 Add '--visualise' toggle if you want to visualise the worker using env.render() as follows:
 
-`python train.py --num-workers 2 --env-id PongDeterministic-v3 --log-dir /tmp/pong --visualise`
+`python train.py --num-workers 2 --env-id PongDeterministic-v4 --log-dir /tmp/pong --visualise`
 
 ![pong](https://github.com/openai/universe-starter-agent/raw/master/imgs/tb_pong.png "Pong")
 
@@ -87,7 +87,7 @@ Note that the default behavior of `train.py` is to start the remotes on a local 
 
 ### VNC Pong
 
-`python train.py --num-workers 2 --env-id gym-core.PongDeterministic-v3 --log-dir /tmp/vncpong`
+`python train.py --num-workers 2 --env-id gym-core.PongDeterministic-v4 --log-dir /tmp/vncpong`
 
 _Peeking into the agent's environment with TurboVNC_
 
@@ -122,7 +122,7 @@ environment with the `Logger` wrapper, as done in
 Generally speaking, environments that are most affected by lag are
 games that place a lot of emphasis on reaction time.  For example,
 this agent is able to solve VNC Pong
-(`gym-core.PongDeterministic-v3`) in under 2 hours when both the agent
+(`gym-core.PongDeterministic-v4`) in under 2 hours when both the agent
 and the environment are co-located on the cloud, but this agent had
 difficulty solving VNC Pong when the environment was on the cloud
 while the agent was not.  This issue affects environments that place


### PR DESCRIPTION
The demo as specified in the README requires a deprecated version of PongDeterministic. Running after a clean install on my computer results in:

```
Traceback (most recent call last):
  File "/Users/generativist/RL/external/gym/gym/envs/registration.py", line 137, in spec
    return self.env_specs[id]
KeyError: 'PongDeterministic-v3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "worker.py", line 152, in <module>
    tf.app.run()
  File "/Users/generativist/anaconda/envs/odin/lib/python3.5/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "worker.py", line 144, in main
    run(args, server)
  File "worker.py", line 26, in run
    env = create_env(args.env_id, client_id=str(args.task), remotes=args.remotes)
  File "/Users/generativist/RL/external/universe-starter-agent/envs.py", line 18, in create_env
    spec = gym.spec(env_id)
  File "/Users/generativist/RL/external/gym/gym/envs/registration.py", line 164, in spec
    return registry.spec(id)
  File "/Users/generativist/RL/external/gym/gym/envs/registration.py", line 145, in spec
    raise error.DeprecatedEnv('Env {} not found (valid versions include {})'.format(id, matching_envs))
gym.error.DeprecatedEnv: Env PongDeterministic-v3 not found (valid versions include ['PongDeterministic-v4', 'PongDeterministic-v0'])
```
This output was produced by the window calling,

```sh
CUDA_VISIBLE_DEVICES= /Users/generativist/anaconda/envs/odin/bin/python worker.py --log-dir /tmp/pong --env-id PongDeterministic-v3 --num-workers 2 --visualise --job-name worker --task 0 --remotes 1
```

Changing to `PongDeterministic-v4` worked.