### PR TITLE
Readme now links to conda.anaconda.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install "gym[atari]"
 pip install universe
 pip install six
 pip install tensorflow
-conda install -y -c https://conda.binstar.org/menpo opencv3
+conda install -y -c https://conda.anaconda.org/menpo opencv3
 conda install -y numpy
 conda install -y scipy
 ```


### PR DESCRIPTION
Replaced `https://conda.binstar.org/menpo` with `https://conda.anaconda.org/menpo` in `conda install`. The old version gives a following error:

```
$ conda install -y -c https://conda.binstar.org/menpo opencv3
Fetching package metadata .........

CondaHTTPError: HTTP None None
for url <None>

An HTTP error occurred when trying to retrieve this URL.
SSLError(SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)'),),)
```